### PR TITLE
Introduce the kubelet container

### DIFF
--- a/kubelet/Dockerfile
+++ b/kubelet/Dockerfile
@@ -1,0 +1,45 @@
+FROM gcr.io/google_containers/hyperkube-amd64:v1.2.4
+MAINTAINER MidoNet (http://midonet.org)
+
+# We don't need the kube-proxy
+RUN rm /etc/kubernetes/manifests/kube-proxy.json
+
+# MidoNet configuration files
+ADD conf/midonet.list /etc/apt/sources.list.d/midonet.list
+ADD conf/kuryr.conf /usr/libexec/kubernetes/kubelet-plugins/net/exec/kuryr.conf
+ADD scripts/run_kubelet.sh /kubelet
+
+# # Install Java 8 (jessie-backports must be added)
+RUN echo "deb http://httpredir.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
+    && apt-get -qqy update \
+    && apt-get install -qy openjdk-8-jdk --no-install-recommends \
+    && rm -fr /var/lib/apt/lists/*
+
+# Midonet key
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv \
+     E9996503AEB005066261D3F38DDA494E99143E75
+
+# We need to have the CNI driver installed in the kubelet container
+# Clone the kuryr project and install
+RUN apt-get -qy update \
+    && apt-get -qy install git python3 python3-dev build-essential --no-install-recommends \
+    && curl -s https://bootstrap.pypa.io/get-pip.py | python3 1>/dev/null \
+    && git clone http://github.com/midonet/kuryr /opt/kuryr -b k8s \
+    && cd /opt/kuryr \
+    && pip3 install . \
+    && rm -fr /var/lib/apt/lists/*
+
+# Install mm-ctl
+RUN apt-get -qy update \
+    && apt-get install -qqy python-setproctitle \
+    && cd /tmp \
+    && apt-get download midolman \
+    && mv midolman* midolman.deb \
+    && dpkg -i --ignore-depends=openvswitch-datapath-dkms,bridge-utils,haproxy,quagga,libreswan,iproute,midonet-tools /tmp/midolman.deb \
+    && rm -fr /var/lib/apt/lists/* /etc/apt/sources.list.d/*
+
+# Set ENV VARS
+ENV ZK_ENDPOINTS="127.0.0.1:2181"
+ENV UUID=""
+
+CMD ["/kubelet"]

--- a/kubelet/README.md
+++ b/kubelet/README.md
@@ -1,0 +1,40 @@
+# Hyperkube Kubelet
+
+This container runs a Kubelet container which, in turns, spawns the rest of
+Kubernetes services (api, etcd) to have an inmediate suite of K8s to be used.
+It is configured to be used by MidoNet with Neutron, by configuring the Kuryr's
+CNI driver and the `mm-ctl` utility to bind containers.
+
+## How to run it
+
+An example command line is:
+
+```bash
+docker run -d --name kubelet \
+  -e ZK_ENDPOINTS=172.17.0.83:2181,172.17.0.83:2181,172.17.0.85:2182 \
+  -e UUID="a293fed0-f7dc-40e6-b01d-c688cfa02429" \
+  --pid=host \
+  --net=host \
+  --privileged=true \
+  -v ${HOME}/logs:/var/log/midonet-cluster \
+  -v /:/rootfs:ro
+  -v /sys:/sys:ro
+  -v /var/lib/docker:/var/lib/docker:rw
+  -v /var/lib/kubelet:/var/lib/kubelet:rw
+  -v /var/run:/var/run:rw
+   midonet/kubelet
+```
+
+where:
+
+* ZK\_ENDPOINTS is a comma separated list of all the ip:ports serving
+  Apache Zookeeper.
+* UUID is an optional environment variable that allows you to spawn a container
+  that is identified with that uuid. If you tear it down and start it again
+  with the same UUID, it will take the place and configurations of the previous
+  one. If it is not passed, each container run will get a new uuid.
+* It is prepared to run at host level because it spawns another docker
+  containers (no docker-in-docker considered yet). So the `pid` and the `net`
+  should be defined at host level, and several volumes *MUST* be mounted. The only
+  optional one in the example is the `/var/log/midonet-cluster` one, but we still
+  recommend to mount it.

--- a/kubelet/conf/kuryr.conf
+++ b/kubelet/conf/kuryr.conf
@@ -1,0 +1,4 @@
+{
+  "name": "kuryr",
+  "type": "kuryr"
+}

--- a/kubelet/conf/midonet.list
+++ b/kubelet/conf/midonet.list
@@ -1,0 +1,2 @@
+deb http://builds.midonet.org/midonet-5 stable main
+deb http://builds.midonet.org/misc stable main

--- a/kubelet/scripts/run_kubelet.sh
+++ b/kubelet/scripts/run_kubelet.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+mkdir -p /etc/kuryr/
+cat << EOF > /etc/kuryr/kuryr.conf
+[DEFAULT]
+
+bindir = /usr/local/lib/python3.4/dist-packages/usr/libexec/kuryr
+EOF
+
+HOST_ID_FILE='/etc/midonet_host_id.properties'
+MIDOLMAN_CONF_FILE='/etc/midolman/midolman.conf'
+
+if [ ! -f ${MIDOLMAN_CONF_FILE} ] || [ "$(stat -c '%m' /etc/midolman)" = "/" ]; then
+    cat > /etc/midolman/midolman.conf << EOF
+[zookeeper]
+zookeeper_hosts = "${ZK_ENDPOINTS}"
+EOF
+fi
+
+
+# Do not write things to /etc if the user mounted his own config
+if [ ! -f ${HOST_ID_FILE} ] || [ "$(stat -c '%m' ${HOST_ID_FILE})" = "/" ]; then
+
+    # if a UUID was not supplied, we'll get a new one with each `docker run`
+    if [ "$UUID" = "" ]; then
+        UUID=$(python -c "import uuid; print(uuid.uuid4())")
+    fi
+    echo "host_uuid=$UUID" > ${HOST_ID_FILE}
+fi
+
+/hyperkube kubelet --network-plugin=cni --hostname-override='127.0.0.1' --address='0.0.0.0' --api-servers=http://localhost:8080 --cluster-dns=10.0.0.10 --cluster-domain=cluster.local --config=/etc/kubernetes/manifests --allow-privileged=true --v=2


### PR DESCRIPTION
Prepare the container that runs the /hyperkube utility to spawn all the
K8s services plus the Kuryr's CNI driver and MidoNet's `mm-ctl` binary
to run the bindings.
