### PR TITLE
Make `api` and `etc` services optional

### DIFF
--- a/kubelet/Dockerfile
+++ b/kubelet/Dockerfile
@@ -41,5 +41,8 @@ RUN apt-get -qy update \
 # Set ENV VARS
 ENV ZK_ENDPOINTS="127.0.0.1:2181"
 ENV UUID=""
+ENV RUN_API=""
+ENV RUN_ETCD=""
+ENV K8S_API="http://localhost:8080"
 
 CMD ["/kubelet"]

--- a/kubelet/README.md
+++ b/kubelet/README.md
@@ -1,9 +1,9 @@
 # Hyperkube Kubelet
 
 This container runs a Kubelet container which, in turns, spawns the rest of
-Kubernetes services (api, etcd) to have an inmediate suite of K8s to be used.
-It is configured to be used by MidoNet with Neutron, by configuring the Kuryr's
-CNI driver and the `mm-ctl` utility to bind containers.
+Kubernetes services (api, etcd if needed) to have an inmediate suite of K8s to
+be used.  It is configured to be used by MidoNet with Neutron, by configuring
+the Kuryr's CNI driver and the `mm-ctl` utility to bind containers.
 
 ## How to run it
 
@@ -17,11 +17,14 @@ docker run -d --name kubelet \
   --net=host \
   --privileged=true \
   -v ${HOME}/logs:/var/log/midonet-cluster \
-  -v /:/rootfs:ro
-  -v /sys:/sys:ro
-  -v /var/lib/docker:/var/lib/docker:rw
-  -v /var/lib/kubelet:/var/lib/kubelet:rw
-  -v /var/run:/var/run:rw
+  -v /:/rootfs:ro \
+  -v /sys:/sys:ro \
+  -v /var/lib/docker:/var/lib/docker:rw \
+  -v /var/lib/kubelet:/var/lib/kubelet:rw \
+  -v /var/run:/var/run:rw \
+  -e K8S_API='http://127.0.0.1:8080' \
+  -e RUN_API='true' \
+  -e RUN_ETCD='true' \
    midonet/kubelet
 ```
 
@@ -38,3 +41,8 @@ where:
   should be defined at host level, and several volumes *MUST* be mounted. The only
   optional one in the example is the `/var/log/midonet-cluster` one, but we still
   recommend to mount it.
+* The K8S\_API env var is the url where to connect to retrieve API events.
+* Kubelet is spawned alone by default, but you have the chance to run the `api` and
+  `etc` to have a local k8s deployment quickly. Just set the env vars RUN\_API and
+  RUN\_ETCD as true. In this case you don't need to set the K8S\_API because is 
+  already `localhost` by default.

--- a/kubelet/scripts/run_kubelet.sh
+++ b/kubelet/scripts/run_kubelet.sh
@@ -28,4 +28,15 @@ if [ ! -f ${HOST_ID_FILE} ] || [ "$(stat -c '%m' ${HOST_ID_FILE})" = "/" ]; then
     echo "host_uuid=$UUID" > ${HOST_ID_FILE}
 fi
 
-/hyperkube kubelet --network-plugin=cni --hostname-override='127.0.0.1' --address='0.0.0.0' --api-servers=http://localhost:8080 --cluster-dns=10.0.0.10 --cluster-domain=cluster.local --config=/etc/kubernetes/manifests --allow-privileged=true --v=2
+if [ "$RUN_API" = "" ]; then
+    rm /etc/kubernetes/manifests/master.json
+else
+    # Bind the api to all addresses
+    sed -i s/--insecure-bind-address=127.0.0.1/--insecure-bind-address=0.0.0.0/ /etc/kubernetes/manifests/master.json
+fi
+
+if [ "$RUN_ETCD" = "" ]; then
+    rm /etc/kubernetes/manifests/etcd.json
+fi
+
+/hyperkube kubelet --network-plugin=cni --hostname-override='127.0.0.1' --address='0.0.0.0' --api-servers=${K8S_API} --cluster-dns=10.0.0.10 --cluster-domain=cluster.local --config=/etc/kubernetes/manifests --allow-privileged=true --v=2


### PR DESCRIPTION
Create env vars to let the user choose if he wants to run the rest of
the K8s services (local standalone machine) or whether she prefers to
run only Kubelet.

The default behaviour is standalone kubelet.
