### PR TITLE
utils: Container with MidoNet cli utils

### DIFF
--- a/utils/Dockerfile
+++ b/utils/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:14.04
+MAINTAINER MidoNet (https://www.midonet.org)
+
+ADD conf/midonet.list /etc/apt/sources.list.d/midonet.list
+
+RUN set -xe \
+  \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv \
+  E9996503AEB005066261D3F38DDA494E99143E75 \
+  && apt-get -qy update \
+  && apt-get -qy dist-upgrade \
+  \
+  && apt-get -qy install software-properties-common \
+  && add-apt-repository -y ppa:openjdk-r/ppa \
+  && apt-get -qy update \
+  && apt-get -qy install openjdk-8-jre --no-install-recommends \
+  \
+  && apt-get -qy install midonet-tools \
+    python-midonetclient \
+  \
+  && apt-get -qy remove --auto-remove software-properties-common \
+  && rm -fr /var/lib/apt/lists/* /etc/apt/sources.list.d/* \
+  \
+  && mkdir -p /home/midonet \
+  && mkdir -p /etc/midonet \
+  && touch /etc/midonet_host_id.properties \
+  && groupadd -r midonet -g 413 \
+  && useradd -u 411 -r -g midonet -d /home/midonet -s /sbin/nologin -c \
+     "MidoNet utils docker image user" midonet \
+  && chown -R midonet:midonet /home/midonet /etc/midonet \
+     /etc/midonet_host_id.properties
+
+ADD scripts/run-cmd.sh /cli
+
+ENV ZK_ENDPOINTS="127.0.0.1:2181"
+ENV CLUSTER_URL="http://127.0.0.1:8181"
+ENV USERNAME="admin"
+ENV PASSWORD="admin"
+ENV PROJECT="admin"
+ENV UUID=""
+
+USER midonet
+
+ENTRYPOINT ["/cli"]

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,53 @@
+# MidoNet utils
+
+This container is designed to give you access to common MidoNet command line
+administration tools
+
+## How to run it
+
+It gives you access to both midonet-cli and mn-conf
+
+### MidoNet CLI
+
+An example non-interactive command line is:
+
+```bash
+docker run --rm \
+  -e CLUSTER_URL=http://172.17.0.7:8181/midonet-api \
+  midonet/utils cli -e host list
+```
+
+To get into interactive mode:
+
+```bash
+docker run --rm \
+  -e CLUSTER_URL=http://172.17.0.7:8181/midonet-api \
+  midonet/utils cli
+```
+
+where:
+* CLUSTER\_URL is the url to the MidoNet API endpoint to connect to.
+
+Other available options:
+* USERNAME is the Keystone username with admin role to use to connect to
+  the MidoNet cluster. (Default "admin").
+* PASSWORD is the password for the above USERNAME. (Default "admin").
+* PROJECT is the Keystone project for the above USERNAME. (Default "admin").
+
+### mn-conf
+
+An example non-interactive command line is:
+
+```bash
+docker run -ti --rm \
+  -e ZK_ENDPOINTS=172.17.0.6:2181,172.17.0.5:2181,172.17.0.4:2182 \
+  celebdor/utils conf dump
+
+where:
+* ZK\_ENDPOINTS is a comma separated list of all the ip:ports serving
+  Apache Zookeeper.
+* UUID is an optional environment variable that allows you to spawn a container
+  that is identified with that uuid. It should allow you to impersonate a host
+  and set specific local configuration for that host.
+* You can also mount an /etc/midonet volume to provide the above configurations
+  instead

--- a/utils/conf/midonet.list
+++ b/utils/conf/midonet.list
@@ -1,0 +1,2 @@
+deb http://builds.midonet.org/midonet-5 stable main
+deb http://builds.midonet.org/misc stable main

--- a/utils/scripts/run-cmd.sh
+++ b/utils/scripts/run-cmd.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+if [ $# = 0 ]; then
+    echo "You must provide a command name to run a MidoNet utility"
+    exit 2
+fi
+
+UTILITY=$1
+
+shift
+
+case "$UTILITY" in
+    midonet|midonet-cli|cli)
+        if [ "$CLUSTER_URL" = "" ] || [ "$USERNAME" = "" ] || \
+           [ "$PASSWORD" = "" ]; then
+            echo "Missing MidoNet Cluster URL or credentials."
+            exit 2
+        fi
+
+        DIR="/home/midonet"
+
+        if [ ! -d "$DIR" ] || [ "$(stat -c '%m' "$DIR")" = "/" ]; then
+            cat > "$DIR/.midonetrc" << EOF
+[cli]
+api_url = $CLUSTER_URL
+username = $USERNAME
+password = $PASSWORD
+project_id = $PROJECT
+EOF
+        fi
+        midonet-cli "$@"
+        exit $?
+        ;;
+    mn-conf|conf)
+        if [ "$ZK_ENDPOINTS" = "" ]; then
+            echo "Missing Zookeeper endpoints to call $UTILITY"
+            exit 2
+        fi
+
+        HOST_ID_FILE="/etc/midonet_host_id.properties"
+        # Do not write things to /etc if the user mounted his own config
+        if [ ! -f $HOST_ID_FILE ] || \
+           [ "$(stat -c '%m' "$HOST_ID_FILE")" = "/" ]; then
+
+            # if a UUID was not supplied, we'll get a new one with each
+            # `docker run`
+            if [ "$UUID" != "" ]; then
+                echo "host_uuid=$UUID" > /etc/midonet_host_id.properties
+            fi
+        fi
+
+        DIR="/etc/midonet"
+
+        if [ ! -d "$DIR" ] || [ "$(stat -c '%m' "$DIR")" = "/" ]; then
+            mkdir -p "$DIR"
+            cat > "$DIR/midonet.conf" << EOF
+[zookeeper]
+zookeeper_hosts = "${ZK_ENDPOINTS}"
+EOF
+        fi
+        mn-conf "$@"
+        exit $?
+        ;;
+    *)
+        echo "Unknown utility $UTILITY"
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
It is very useful to have a container with the necessary tools to
register and set configurations. For example, it can be useful to
define systemd services that auto register the hosts to the tunnel
zone.

Signed-off-by: Antoni Segura Puimedon toni@midokura.com
