### PR TITLE
kubelet: fix missing '\'

### DIFF
--- a/kubelet/scripts/run_kubelet.sh
+++ b/kubelet/scripts/run_kubelet.sh
@@ -31,7 +31,7 @@ fi
 /hyperkube kubelet \
   --allow-privileged=true \
   --api-servers="http://${MASTER_IP}:8080" \
-  --v=2
+  --v=2 \
   --address='0.0.0.0' \
   --enable-server \
   --containerized \


### PR DESCRIPTION
The end of line was not escaped and as such, the options that were
after it were ignored.

Signed-off-by: Antoni Segura Puimedon toni@midokura.com
