### PR TITLE
kubelet: allow CNI to target a remote kube master

### DIFF
--- a/kubelet/scripts/run_kubelet.sh
+++ b/kubelet/scripts/run_kubelet.sh
@@ -3,8 +3,10 @@
 mkdir -p /etc/kuryr/
 cat << EOF > /etc/kuryr/kuryr.conf
 [DEFAULT]
+bindir = /opt/kuryr/usr/libexec/kuryr
 
-bindir = /usr/local/lib/python3.4/dist-packages/usr/libexec/kuryr
+[k8s]
+api_root = http://${MASTER_IP}:8080
 EOF
 
 HOST_ID_FILE='/etc/midonet_host_id.properties'


### PR DESCRIPTION
Without this patch, the following two bugs were happening:
- CNI could not find the binding executables,
- CNI could not reach remote K8s API servers to request info about
  PODS' Neutron ports.

Signed-off-by: Antoni Segura Puimedon toni@midokura.com
