### PR TITLE
cluster: Remove agent configuration

### DIFF
--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -26,9 +26,6 @@ ENV KEYSTONE_TENANT_NAME="admin"
 ENV KEYSTONE_ADMIN_TOKEN="admintoken"
 ENV UUID=""
 
-# Agent-related cluster level configuration
-ENV AGENT_LOG_LEVEL="INFO"
-
 VOLUME /var/log/midonet-cluster
 
 CMD ["/cluster"]

--- a/cluster/Dockerfile-arm64
+++ b/cluster/Dockerfile-arm64
@@ -56,9 +56,6 @@ ENV KEYSTONE_TENANT_NAME="admin"
 ENV KEYSTONE_ADMIN_TOKEN="admintoken"
 ENV UUID=""
 
-# Agent-related cluster level configuration
-ENV AGENT_LOG_LEVEL="INFO"
-
 VOLUME /var/log/midonet-cluster
 
 CMD ["/cluster"]

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -35,8 +35,6 @@ where:
   having to enter the container.
 
 Other available options:
-* AGENT\_LOG\_LEVEL: which allows you to change the logging level that is used
-  by the MidoNet agents in the cluster. It defaults to 'INFO'.
 * C\_SERVERS: the comma-separated IPs of the cassandra servers in the cluster.
   If it is not provided, some MidoNet features like flow tracing will be
   disabled.

--- a/cluster/scripts/run-cluster.sh
+++ b/cluster/scripts/run-cluster.sh
@@ -61,31 +61,6 @@ echo "Setting up the cluster configuration..."
         zookeeper_hosts = "$ZK_ENDPOINTS"
     }
 
-    agent {
-        midolman {
-            bgp_keepalive: 1s
-            bgp_holdtime: 3s
-            bgp_connect_retry: 1s
-            lock_memory: true
-            simulation_threads: 2
-            output_channels: 2
-        }
-
-        datapath {
-            max_flow_count: 1500000
-            send_buffer_pool_max_size: 16384
-            send_buffer_pool_initial_size: 4096
-        }
-
-        loggers.root: $AGENT_LOG_LEVEL
-
-        haproxy_health_monitor {
-            namespace_cleanup: true
-            health_monitor_enable: true
-            haproxy_file_loc: /etc/midolman/l4lb/
-        }
-    }
-
     $AUTH_CONF
 
 EOF


### PR DESCRIPTION
To avoid fragile dependencies among components.
Also, having those setting hardcoded here makes TEMPLATE
setting in agent less useful.
The default setting should be good enough for now.

Signed-off-by: YAMAMOTO Takashi <yamamoto@midokura.com>