### PR TITLE
Allow specific midonet commit/repo to build in ARM

### DIFF
--- a/agent/Dockerfile-arm64
+++ b/agent/Dockerfile-arm64
@@ -52,6 +52,7 @@ RUN ar x midolman_*.deb && tar xzf control.tar.gz && \
 # Final container using generated packages
 FROM ubuntu:xenial
 MAINTAINER MidoNet (https://www.midonet.org)
+ARG DEBIAN_FRONTEND=noninteractive
 RUN set -xe \
   \
   && apt update -qy && apt install -qy apt-utils gdebi-core gnupg\

--- a/agent/Dockerfile-arm64
+++ b/agent/Dockerfile-arm64
@@ -22,6 +22,8 @@ RUN wget https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.
 
 # Intermediate container to build midonet packages
 FROM protobuf as packager1
+ARG MIDONET_REPO=https://github.com/midonet/midonet
+ARG MIDONET_COMMIT=master
 RUN apt update && apt install --force-yes -y --no-install-recommends \
     g++ make ruby-dev ruby rpm debsigs expect openjdk-8-jdk-headless \
     autoconf python3-pip python-pip git && \
@@ -29,7 +31,9 @@ RUN apt update && apt install --force-yes -y --no-install-recommends \
     pip3 install setuptools && \
     pip install setuptools && \
     pip install simplejson
-RUN git clone https://github.com/midonet/midonet && cd midonet && \
+RUN git clone $MIDONET_REPO && cd midonet && \
+    git fetch origin +refs/heads/*:refs/remotes/origin/* +refs/changes/*:refs/changes/* +refs/pull/*/head:refs/remotes/origin/pr/* && \
+    git checkout $MIDONET_COMMIT && \
     ./gradlew clean debian -x test -x integration
 
 # Intermediate container to remove libreswan and vpp dependencies


### PR DESCRIPTION
This adds two arguments to the Dockerfile-arm64 to allow specify the
midonet source repository and the commit (or branch) to checkout from
it and used to build the debian packages used by the image. The names
and default values are:

  MIDONET_REPO=https://github.com/midonet/midonet
  MIDONET_COMMIT=master

The intention is that source code that is not merged in midonet offical
master branch can be tested (for example, gerrithub, pull request, etc).

Signed-off-by: Miguel Herranz <miguel@midokura.com>